### PR TITLE
Add docker-compose for running local mongo

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,8 @@
+version: "3"
+
+services:
+  database:
+    image: mongodb/mongodb-community-server:6.0-ubi8
+    restart: always
+    ports:
+        - 27017:27017


### PR DESCRIPTION
Simple Docker setup for running MongoDB locally for development and testing purposes.